### PR TITLE
fix: "realsed" to "release"

### DIFF
--- a/addons/dotenv/dotenv.gd
+++ b/addons/dotenv/dotenv.gd
@@ -35,7 +35,7 @@ static func load_(path: String, recursive := false, continue_in_release := false
 # This loads a file directly, its better to use load_() because it has checks
 static func load_env_file(path: String, continue_in_release: bool) -> void:
 	# It isnt recommended to use env files in a production build, use github secrets
-	if OS.has_feature('realesed') and not continue_in_release:
+	if OS.has_feature('release') and not continue_in_release:
 		return
 
 	if not FileAccess.file_exists(path):


### PR DESCRIPTION
The stop on release function wasn't working thanks to a typo:

- [Godot Engine 4.3 documentation in English/Export/Feature Tags](https://docs.godotengine.org/en/stable/tutorials/export/feature_tags.html)

in the line 38 of the main dotenv.gd script there is a line:
```py
38    if OS.has_feature('realesed') and not continue_in_release:
```

that was changed for:
```py
38    if OS.has_feature('release') and not continue_in_release:
```